### PR TITLE
if no gene_name in gtf

### DIFF
--- a/gtftools/gtftools.py
+++ b/gtftools/gtftools.py
@@ -198,7 +198,10 @@ def get_tss_region(GTFfile,w='1000-300',tss_bed_file='',chroms=list(map(str,rang
             strand = table[6] 
             tcx = line.split('transcript_id')[1].split('"')[1]
             geneid = line.split('gene_id')[1].split('"')[1]
-            genesymbol = line.split('gene_name')[1].split('"')[1]
+            if "gene_name" in line:
+                genesymbol = line.split('gene_name')[1].split('"')[1]
+            else:
+                genesymbol = geneid
             if  strand == "+":
                 iregion = [chrom,int(table[3])-1-wup,int(table[3])-1+wdown,strand,tcx,geneid,genesymbol]
             elif strand == '-':
@@ -228,7 +231,10 @@ def get_intergenic_region(GTFfile,intergenic_region_file='',chroms=list(map(str,
                 left  = int(table[3])-1
                 right = int(table[4]) 
                 ensid  = line.split('gene_id')[1].split('"')[1]
-                symbol = line.split('gene_name')[1].split('"')[1].upper()
+            if "gene_name" in line:
+                symbol = line.split('gene_name')[1].split('"')[1]
+            else:
+                symbol = ensid
                 record = (chrom,left,right,table[6])
                 if chrom in genebed:
                     genebed[chrom].append(record)
@@ -264,7 +270,10 @@ def get_gene_bed(GTFfile,gene_bed_file='',chroms=list(map(str,range(1,23)))+['X'
 			if table[2] == "gene":
 				#print(line)
 				ensid  = line.split('gene_id')[1].split('"')[1]			
-				symbol = line.split('gene_name')[1].split('"')[1].upper()			
+				if "gene_name" in line:
+					symbol = line.split('gene_name')[1].split('"')[1]
+				else:
+					symbol = ensid		
 				record = (table[0],int(table[3])-1,int(table[4]),table[6],ensid,symbol)
 
 				if 'gene_biotype' in line:
@@ -325,7 +334,10 @@ def get_cissnp_bed(GTFfile,cissnp_file='',chroms=list(map(str,range(1,23)))+['X'
 		if chrom in chroms:
 			if table[2] == "gene":
 				ensid  = line.split('gene_id')[1].split('"')[1]			
-				symbol = line.split('gene_name')[1].split('"')[1]		
+				if "gene_name" in line:
+					symbol = line.split('gene_name')[1].split('"')[1]
+				else:
+					symbol = ensid		
 				
 				
 				start  = int(table[3])
@@ -393,7 +405,10 @@ def get_isoform_bed(GTFfile,isoform_bed_file='',chroms=list(map(str,range(1,23))
 			if table[2] == "transcript":
 				isoformid  = line.split('transcript_id')[1].split('"')[1]			
 				ensid  = line.split('gene_id')[1].split('"')[1]			
-				symbol = line.split('gene_name')[1].split('"')[1].upper()			
+				if "gene_name" in line:
+					symbol = line.split('gene_name')[1].split('"')[1]
+				else:
+					symbol = ensid				
 				record = (table[0],int(table[3])-1,int(table[4]),table[6],isoformid,ensid,symbol)
 
 


### PR DESCRIPTION
**if no gene_name in gtf**

In recent release of Homo_sapiens.GRCh38.109.gtf,  there is no "gene_name" in some lines.
If I use "gtftools --gene gene Homo_sapiens.GRCh38.109.gtf" , it will throw an error.

```python
File "/APP/mambaforge/envs/p2/lib/python2.7/site-packages/gtftools/gtftools.py", line 267, in get_gene_bed
    symbol = line.split('gene_name')[1].split('"')[1].upper()
IndexError: list index out of range)
```

For example:
| | | | | | | | | |
|-|-|-|-|-|-|-|-|-|
|1|havana|gene|5301928|5307394|.|-|.|gene_id "ENSG00000284616"; gene_version "1"; gene_source "havana"; gene_biotype "lncRNA";|
|1|havana|transcript|5301928|5307394|.|-|.|gene_id "ENSG00000284616"; gene_version "1"; transcript_id "ENST00000641871"; transcript_version "1"; gene_source "havana"; gene_biotype "lncRNA"; transcript_source "havana"; transcript_biotype "lncRNA"; tag "basic"; tag "Ensembl_canonical";|
|1|havana|exon|5306942|5307394|.|-|.|gene_id "ENSG00000284616"; gene_version "1"; transcript_id "ENST00000641871"; transcript_version "1"; exon_number "1"; gene_source "havana"; gene_biotype "lncRNA"; transcript_source "havana"; transcript_biotype "lncRNA"; exon_id "ENSE00003812690"; exon_version "1"; tag "basic"; tag "Ensembl_canonical";|


